### PR TITLE
Implement DH curve25519 private/public gen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/byarbrough/wgconf
 
 go 1.18
+
+require golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/peer.go
+++ b/peer.go
@@ -1,0 +1,39 @@
+package wgconf
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+// GenKey returns a base64 encoded private key
+func GenKey() (string, error) {
+	scalar := make([]byte, 32)
+	_, err := rand.Read(scalar)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return "", err
+	}
+	privateKey, err := curve25519.X25519(scalar, curve25519.Basepoint)
+	if err != nil {
+		return "", err
+	}
+	encodedKey := base64.StdEncoding.EncodeToString(privateKey)
+	return encodedKey, nil
+}
+
+// PubKey returns a base64 public key for the provided
+// private key
+func PubKey(privateKey string) (string, error) {
+	decodedPrivate, err := base64.StdEncoding.DecodeString(privateKey)
+	if err != nil {
+		return "", err
+	}
+	publicKey, err := curve25519.X25519(decodedPrivate, curve25519.Basepoint)
+	if err != nil {
+		return "", err
+	}
+	encodedPublic := base64.StdEncoding.EncodeToString(publicKey)
+	return encodedPublic, nil
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -1,0 +1,50 @@
+package wgconf_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/byarbrough/wgconf"
+)
+
+func TestGenKey(t *testing.T) {
+	got, err := wgconf.GenKey()
+	if err != nil {
+		t.Error(err)
+	}
+	decodedKey, err := base64.StdEncoding.DecodeString(got)
+	if err != nil {
+		t.Error(err)
+	}
+	keyLength := len(decodedKey)
+	if keyLength != 32 {
+		t.Errorf("Decoded key length must be 32 bytes, got %d for %s", keyLength, got)
+	}
+}
+
+func TestPubKey(t *testing.T) {
+
+	var testCases = []struct {
+		privateKey string
+		want       string
+		expectErr  bool
+	}{
+		{"9zw8/YZQofkzUNWAKVzXO3MA1lgPAsaoX4iwnXl0ECI=", "kvn7tp3wXw/x/Km38ETVg+kNd7UdqFwME3EA5QP29Q4=", false},
+		{"8Cb11CvA9Zn/7jCw21J/OJJ/IINEzPyQaIRMNUfKMXs=", "1rFrurDYGvT3bAgH8OlDlkCJWpvH/NuEgzZgYIi410M=", false},
+		{"NuEgzZgYIi410M=", "", true}, // key too short
+	}
+
+	for _, tc := range testCases {
+		got, err := wgconf.PubKey(tc.privateKey)
+		if err != nil {
+			if tc.expectErr {
+				break
+			} else {
+				t.Error(err)
+			}
+		}
+		if got != tc.want {
+			t.Errorf("Got %s, want %s", got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
WG docs https://www.wireguard.com/protocol/ state that genkey and pubkey use Curve25519 for ECDH. This is implemented https://github.com/WireGuard/wireguard-tools/blob/5b9c1d6d74376d4983a3055078225d95104194f0/src/curve25519.c#L95

According to RFC 8031, publick key uses same scalar multiplication as private key https://www.rfc-editor.org/rfc/rfc8031#section-2

Using Basepoint var "the canonical Curve25519 generator". https://pkg.go.dev/golang.org/x/crypto/curve25519#pkg-variables